### PR TITLE
Migrate to CentOS 7 and glibc 2.17

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,9 +1,9 @@
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.12'
+- '2.17'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -12,6 +8,3 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:
 - linux-64
-zip_keys:
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -2,10 +2,6 @@ BUILD:
 - aarch64-conda_cos7-linux-gnu
 arm_variant_type:
 - sbsa
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -18,6 +14,3 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:
 - linux-aarch64
-zip_keys:
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -12,6 +8,3 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,5 @@
 c_stdlib:
 - vs
-c_stdlib_version:
-- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,3 @@
-c_stdlib:
-- vs
 channel_sources:
 - conda-forge
 channel_targets:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,3 +10,7 @@ github:
 provider:
   linux_aarch64: default
   linux_ppc64le: default
+os_version:
+  linux_64: cos7
+  linux_aarch64: cos7
+  linux_ppc64le: cos7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
   sha256: 8c0c81125d2f0ef6f42bc46723f2c5565863731cf3a3de3ea3e738ea2d7a938f  # [win]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx]
 
 requirements:


### PR DESCRIPTION
According to conda-forge/conda-forge.github.io#2102, the Conda-forge ecosystem is migrating to CentOS 7 and glibc 2.17 this summer.
This pull request proactively migrates this package.